### PR TITLE
Fcrepo 81482904

### DIFF
--- a/src/main/java/org/fcrepo/oai/service/OAIProviderService.java
+++ b/src/main/java/org/fcrepo/oai/service/OAIProviderService.java
@@ -305,8 +305,7 @@ public class OAIProviderService {
         id.setBaseURL(uriInfo.getBaseUri().toASCIIString());
         id.setEarliestDatestamp("INSTALL_DATE");
         id.setProtocolVersion("2.0");
-        //id.setRepositoryName("Fedora 4");
-        //final String repoVersion = root.getProperty("repository.jcr.repository.version").getString();
+
         if (repoName == null) {
             id.setRepositoryName("Fedora 4");
         } else {
@@ -325,10 +324,6 @@ public class OAIProviderService {
             desc.setAny(new JAXBElement<String>(new QName("general"), String.class, repoDescription));
         }
         id.getDescription().add(0, desc);
-        //id.getAdminEmail().add(0,"admin@example.com");
-        //final DescriptionType desc = this.oaiFactory.createDescriptionType();
-        //desc.setAny(new JAXBElement<String>(new QName("general"), String.class, "An example repository description"));
-        //id.getDescription().add(0, desc);
 
         final RequestType req = oaiFactory.createRequestType();
         req.setVerb(VerbType.IDENTIFY);


### PR DESCRIPTION
The parameter for the fields in the oai.xml are:

<property name="repoName" value="Fedora4 OAI Repository"/>
<property name="adminEmail" value="admin@example.com"/>
<property name="repoDescription" value="Sample Fedora4 Respoitory"/>

If the fields don't exist in the oai.xml, it uses the original "canned" version of that field.

Sorry, I couldn't figure out just yet how to add the repo version number. I'll try to get that working.
